### PR TITLE
Fix #8 by upgrading datauri to <0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "svg"
   ],
   "dependencies": {
-    "datauri": "0.5.5",
+    "datauri": "<0.8",
     "underscore": "~1.5.2"
   }
 }


### PR DESCRIPTION
This change adds support for Node v4.0+.

The rationale for choosing <0.8 is that v0.8 of datauri breaks
compatibility with Node v0.8, which grunt-datauri-variables supports.