### PR TITLE
Update README.md with `files` format used in spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ grunt.initConfig({
     },
     your_target: {
       files: {
-        src: "images/**/*.{png,jpg,gif,svg}"
-        dest: "generated/_datauri_variables.scss"
+        "generated/_datauri_variables.scss": "images/**/*.{png,jpg,gif,svg}"
       }
     },
   },


### PR DESCRIPTION
The format given in the documentation doesn't work, whereas the spec's notation does.

Doesn't work:

```
files: {
    src: ...,
    dest: ...
}
```

Does work:

```
files: {
    "...": "..."
}
```